### PR TITLE
Home list fix

### DIFF
--- a/server/ApiAdapter.js
+++ b/server/ApiAdapter.js
@@ -11,4 +11,9 @@ export default class ApiAdapter {
         const data = await res.json();
         return data;
     }
-}
+    async loadMetaData(endpoint = '') {
+        const res = await fetch(this.baseUrl + endpoint);
+        const data = await res.json();
+        return data.meta;
+    }
+}   

--- a/server/screeningsList.js
+++ b/server/screeningsList.js
@@ -1,19 +1,37 @@
 import fetch from 'node-fetch';
+import ApiAdapter from './ApiAdapter.js';
+
+const api = new ApiAdapter();
+const screeningsEndpoint = '/screenings'
+
+const getTotal = async () => {
+const metadata = await api.loadMetaData(screeningsEndpoint);
+    return metadata.pagination.total;
+}
 
 export const getScreeningsWithMovies = {
     loadData : async () => {
+
         const res = await fetch("https://plankton-app-xhkom.ondigitalocean.app/api/screenings?populate=movie");
         const data = await res.json();
 
         return data;
+        
+    },
+    loadAllData : async (total) => {
+            const res = await fetch(`https://plankton-app-xhkom.ondigitalocean.app/api/screenings?populate=movie&pagination[pageSize]=${total}`);
+            const data = await res.json();
+
+            return data;
+        
     }
 }
 // Formatting and filtering JSON to send only relevant data for rendering. 
 export const getScreeningsList = async (apiHandler) => {
-        
-    const data = await apiHandler.loadData();
+   
+    const data = await apiHandler.loadAllData(await getTotal());
     
-    const res = data.data
+    const res = data.data   
     
     .map( array => ({
         id: array.id, 

--- a/test/mockApiAdapter.js
+++ b/test/mockApiAdapter.js
@@ -633,9 +633,650 @@ export const mockApiAdapter = {
                 "page": 1,
                 "pageSize": 25,
                 "pageCount": 2,
-                "total": 36
+                "total": 25
+              }
+            }
+          }
+    },
+    loadAllData: async () => {
+        return {
+            "data": [
+              {
+                "id": 1,
+                "attributes": {
+                  "start_time": "2023-02-01T17:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:02.786Z",
+                  "updatedAt": "2023-01-31T04:27:02.786Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 2,
+                "attributes": {
+                  "start_time": "2023-02-02T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:03.776Z",
+                  "updatedAt": "2023-01-31T04:27:03.776Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 3,
+                "attributes": {
+                  "start_time": "2023-02-02T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:04.047Z",
+                  "updatedAt": "2023-01-31T04:27:04.047Z",
+                  "movie": {
+                    "data": {
+                      "id": 1,
+                      "attributes": {
+                        "title": "Isle of dogs",
+                        "imdbId": "tt5104604",
+                        "intro": "An outbreak of dog flu has spread through the city of **Megasaki, Japan**, and Mayor Kobayashi has demanded all dogs to be sent to Trash Island.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BZDQwOWQ2NmUtZThjZi00MGM0LTkzNDctMzcyMjcyOGI1OGRkXkEyXkFqcGdeQXVyMTA3MDk2NDg2._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T05:58:58.110Z",
+                        "updatedAt": "2023-01-27T07:11:53.523Z",
+                        "publishedAt": "2023-01-23T06:01:31.679Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 4,
+                "attributes": {
+                  "start_time": "2023-02-03T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:04.291Z",
+                  "updatedAt": "2023-01-31T04:27:04.291Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 5,
+                "attributes": {
+                  "start_time": "2023-02-03T17:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:04.532Z",
+                  "updatedAt": "2023-01-31T04:27:04.532Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 6,
+                "attributes": {
+                  "start_time": "2023-02-03T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:04.797Z",
+                  "updatedAt": "2023-01-31T04:27:04.797Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 7,
+                "attributes": {
+                  "start_time": "2023-02-04T17:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:05.473Z",
+                  "updatedAt": "2023-01-31T04:27:05.473Z",
+                  "movie": {
+                    "data": {
+                      "id": 1,
+                      "attributes": {
+                        "title": "Isle of dogs",
+                        "imdbId": "tt5104604",
+                        "intro": "An outbreak of dog flu has spread through the city of **Megasaki, Japan**, and Mayor Kobayashi has demanded all dogs to be sent to Trash Island.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BZDQwOWQ2NmUtZThjZi00MGM0LTkzNDctMzcyMjcyOGI1OGRkXkEyXkFqcGdeQXVyMTA3MDk2NDg2._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T05:58:58.110Z",
+                        "updatedAt": "2023-01-27T07:11:53.523Z",
+                        "publishedAt": "2023-01-23T06:01:31.679Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 8,
+                "attributes": {
+                  "start_time": "2023-02-04T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:05.702Z",
+                  "updatedAt": "2023-01-31T04:27:05.702Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 9,
+                "attributes": {
+                  "start_time": "2023-02-05T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:06.146Z",
+                  "updatedAt": "2023-01-31T04:27:06.146Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 10,
+                "attributes": {
+                  "start_time": "2023-02-05T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:06.843Z",
+                  "updatedAt": "2023-01-31T04:27:06.843Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 11,
+                "attributes": {
+                  "start_time": "2023-02-06T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:07.487Z",
+                  "updatedAt": "2023-01-31T04:27:07.487Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 12,
+                "attributes": {
+                  "start_time": "2023-02-07T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:08.513Z",
+                  "updatedAt": "2023-01-31T04:27:08.513Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 13,
+                "attributes": {
+                  "start_time": "2023-02-08T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:08.770Z",
+                  "updatedAt": "2023-01-31T04:27:08.770Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 14,
+                "attributes": {
+                  "start_time": "2023-02-08T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:09.429Z",
+                  "updatedAt": "2023-01-31T04:27:09.429Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 15,
+                "attributes": {
+                  "start_time": "2023-02-09T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:10.332Z",
+                  "updatedAt": "2023-01-31T04:27:10.332Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 16,
+                "attributes": {
+                  "start_time": "2023-02-10T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:10.585Z",
+                  "updatedAt": "2023-01-31T04:27:10.585Z",
+                  "movie": {
+                    "data": {
+                      "id": 1,
+                      "attributes": {
+                        "title": "Isle of dogs",
+                        "imdbId": "tt5104604",
+                        "intro": "An outbreak of dog flu has spread through the city of **Megasaki, Japan**, and Mayor Kobayashi has demanded all dogs to be sent to Trash Island.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BZDQwOWQ2NmUtZThjZi00MGM0LTkzNDctMzcyMjcyOGI1OGRkXkEyXkFqcGdeQXVyMTA3MDk2NDg2._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T05:58:58.110Z",
+                        "updatedAt": "2023-01-27T07:11:53.523Z",
+                        "publishedAt": "2023-01-23T06:01:31.679Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 17,
+                "attributes": {
+                  "start_time": "2023-02-10T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:11.016Z",
+                  "updatedAt": "2023-01-31T04:27:11.016Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 18,
+                "attributes": {
+                  "start_time": "2023-02-10T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:11.253Z",
+                  "updatedAt": "2023-01-31T04:27:11.253Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 19,
+                "attributes": {
+                  "start_time": "2023-02-11T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:11.468Z",
+                  "updatedAt": "2023-01-31T04:27:11.468Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 20,
+                "attributes": {
+                  "start_time": "2023-02-11T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:11.886Z",
+                  "updatedAt": "2023-01-31T04:27:11.886Z",
+                  "movie": {
+                    "data": {
+                      "id": 4,
+                      "attributes": {
+                        "title": "Min granne Totoro",
+                        "imdbId": "tt0096283",
+                        "intro": "When two girls move to the country to be near their ailing mother, they have **adventures with the wondrous forest spirits** who live nearby.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BYzJjMTYyMjQtZDI0My00ZjE2LTkyNGYtOTllNGQxNDMyZjE0XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T09:15:23.153Z",
+                        "updatedAt": "2023-01-27T07:12:08.242Z",
+                        "publishedAt": "2023-01-23T09:15:43.382Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 21,
+                "attributes": {
+                  "start_time": "2023-02-13T17:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:13.363Z",
+                  "updatedAt": "2023-01-31T04:27:13.363Z",
+                  "movie": {
+                    "data": {
+                      "id": 1,
+                      "attributes": {
+                        "title": "Isle of dogs",
+                        "imdbId": "tt5104604",
+                        "intro": "An outbreak of dog flu has spread through the city of **Megasaki, Japan**, and Mayor Kobayashi has demanded all dogs to be sent to Trash Island.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BZDQwOWQ2NmUtZThjZi00MGM0LTkzNDctMzcyMjcyOGI1OGRkXkEyXkFqcGdeQXVyMTA3MDk2NDg2._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T05:58:58.110Z",
+                        "updatedAt": "2023-01-27T07:11:53.523Z",
+                        "publishedAt": "2023-01-23T06:01:31.679Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 22,
+                "attributes": {
+                  "start_time": "2023-02-14T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:14.053Z",
+                  "updatedAt": "2023-01-31T04:27:14.053Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 23,
+                "attributes": {
+                  "start_time": "2023-02-14T19:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:14.475Z",
+                  "updatedAt": "2023-01-31T04:27:14.475Z",
+                  "movie": {
+                    "data": {
+                      "id": 3,
+                      "attributes": {
+                        "title": "The Shawshank Redemption",
+                        "imdbId": "tt0111161",
+                        "intro": "Over the course of several years, **two convicts form a friendship**, seeking consolation and, eventually, redemption through basic compassion.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T07:17:34.923Z",
+                        "updatedAt": "2023-01-27T07:12:24.582Z",
+                        "publishedAt": "2023-01-23T07:17:39.384Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 24,
+                "attributes": {
+                  "start_time": "2023-02-14T21:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:14.727Z",
+                  "updatedAt": "2023-01-31T04:27:14.727Z",
+                  "movie": {
+                    "data": {
+                      "id": 1,
+                      "attributes": {
+                        "title": "Isle of dogs",
+                        "imdbId": "tt5104604",
+                        "intro": "An outbreak of dog flu has spread through the city of **Megasaki, Japan**, and Mayor Kobayashi has demanded all dogs to be sent to Trash Island.",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BZDQwOWQ2NmUtZThjZi00MGM0LTkzNDctMzcyMjcyOGI1OGRkXkEyXkFqcGdeQXVyMTA3MDk2NDg2._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T05:58:58.110Z",
+                        "updatedAt": "2023-01-27T07:11:53.523Z",
+                        "publishedAt": "2023-01-23T06:01:31.679Z"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "id": 25,
+                "attributes": {
+                  "start_time": "2023-02-15T12:00:00.000Z",
+                  "room": "Stora salongen",
+                  "createdAt": "2023-01-31T04:27:14.976Z",
+                  "updatedAt": "2023-01-31T04:27:14.976Z",
+                  "movie": {
+                    "data": {
+                      "id": 2,
+                      "attributes": {
+                        "title": "Encanto",
+                        "imdbId": "tt2953050",
+                        "intro": "A Colombian teenage girl has to face the frustration of being **the only member of her family** without magical powers.\n\n",
+                        "image": {
+                          "url": "https://m.media-amazon.com/images/M/MV5BNjE5NzA4ZDctOTJkZi00NzM0LTkwOTYtMDI4MmNkMzIxODhkXkEyXkFqcGdeQXVyNjY1MTg4Mzc@._V1_.jpg"
+                        },
+                        "createdAt": "2023-01-23T06:46:24.765Z",
+                        "updatedAt": "2023-01-27T07:11:39.088Z",
+                        "publishedAt": "2023-01-23T06:46:29.324Z"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "meta": {
+              "pagination": {
+                "page": 1,
+                "pageSize": 25,
+                "pageCount": 2,
+                "total": 25
               }
             }
           }
     }
 }
+
+    


### PR DESCRIPTION
This is a fix to the bug that caused the homepage not showing any movies
when the current date had passed the last screening on the first page of the JSON.

This fix adds functionality to fetch meta data in the ApiAdapter class. 

This fix gets the total count of posts in the JSON, and uses pageSize to fetch all posts that then gets passed through filtering. 

I am aware that this would cause problems with large numbers. 